### PR TITLE
Fix ineffective parameter types found on LGTM.com

### DIFF
--- a/src/visualLayout.ts
+++ b/src/visualLayout.ts
@@ -106,7 +106,7 @@ module powerbi.extensibility.visual {
             }, this.minViewportValue);
         }
 
-        private setUpdateObject<T>(object: T, setObjectFn: (T) => void, beforeUpdateFn?: (T) => void): void {
+        private setUpdateObject<T>(object: T, setObjectFn: (object: T) => void, beforeUpdateFn?: (object: T) => void): void {
             object = _.clone(object);
             setObjectFn(VisualLayout.createNotifyChangedObject(object, o => {
                 if (beforeUpdateFn) beforeUpdateFn(object);


### PR DESCRIPTION
In TypeScript, the parameters of a function signature must have a name and may
optionally have a type. A common mistake is to try to omit the name. This means
the type is instead seen as the name. As a result, the parameter type will
default to any since no type was given.

These mistakes were found on LGTM.com, and there are [a couple more minor alerts](https://lgtm.com/projects/g/Microsoft/powerbi-visuals-bulletchart/alerts/).

*(Full disclosure: I'm part of the team behind LGTM.com)*